### PR TITLE
Requests with cookies.txt

### DIFF
--- a/download.py
+++ b/download.py
@@ -3,10 +3,14 @@ import os
 from subprocess import call
 import requests
 from requests.auth import HTTPBasicAuth
+import http.cookiejar
 
 
 def getIframeUrl(source, part):
-    r = requests.get(source)
+    cj = http.cookiejar.MozillaCookieJar('cookies.txt')
+    cj.load()
+
+    r = requests.get(source, cookies = cj)
     bs = bs4.BeautifulSoup(r.content, 'lxml')
     dest = 'https://fast.wistia.net/embed/iframe/{}'
     id = bs.find('li', {'id': 'lesson-part-' + str(part)}).a['data-id']

--- a/download.py
+++ b/download.py
@@ -3,14 +3,14 @@ import os
 from subprocess import call
 import requests
 from requests.auth import HTTPBasicAuth
-import http.cookiejar
+import http.cookiejar #For python 2 replace http.cookiejar with cookielib
 
 
 def getIframeUrl(source, part):
     cj = http.cookiejar.MozillaCookieJar('cookies.txt')
     cj.load()
 
-    r = requests.get(source, cookies = cj)
+    r = requests.get(source, cookies=cj)
     bs = bs4.BeautifulSoup(r.content, 'lxml')
     dest = 'https://fast.wistia.net/embed/iframe/{}'
     id = bs.find('li', {'id': 'lesson-part-' + str(part)}).a['data-id']


### PR DESCRIPTION
In `getIframeUrl`, `r.content` does not contain lesson id for every video except first lesson because only first lesson is available if you are not logged in:

`<li id="lesson-part-8"\n\t\t\t\t\t\t\t\t\tclass="unselectable not-authorised">\n\t\t\t\t\t\t\t\t\t<a href="#part-8"\n\t\t\t\t\t\t\t\t\t class="part-wistia"\n\t\t\t\t\t\t\t\t\t data-st="not-authorised"\n\t\t\t\t\t\t\t\t\t data-id="">`

To fix this, I used cookies.txt in requests so that all id are available

```
import http.cookiejar
cj = http.cookiejar.MozillaCookieJar('cookies.txt')
cj.load()
r = requests.get(source, cookies = cj)
```

http.cookiejar is for python 3, for python 2 and below, replace http.cookiejar with cookielib